### PR TITLE
_selectUserMethod xref fix and UIX thingie

### DIFF
--- a/UserInfoExtensions/Modules/QuickMenuFromSocial.cs
+++ b/UserInfoExtensions/Modules/QuickMenuFromSocial.cs
@@ -33,7 +33,6 @@ namespace UserInfoExtensions.Modules
                 if (player.prop_APIUser_0.id == VRCUtils.ActiveUserInUserInfoMenu.id)
                 {
                     UiManager.CloseBigMenu();
-                    UiManager.OpenQuickMenu();
 
                     UiManager.OpenQuickMenuPage("QuickMenuHere");
                     UiManager.OpenUserInQuickMenu(player.field_Private_APIUser_0);

--- a/VRChatUtilityKit/Ui/UiManager.cs
+++ b/VRChatUtilityKit/Ui/UiManager.cs
@@ -172,7 +172,8 @@ namespace VRChatUtilityKit.Ui
 
             _selectUserMethod = typeof(UserSelectionManager).GetMethods()
                 .First(method => method.Name.StartsWith("Method_Public_Void_APIUser_") && !method.Name.Contains("_PDM_")
-                && XrefUtils.CheckUsedByCount(method, "Method_Public_Virtual_Final_New_Void_IUser_") >= 2);
+                && XrefUtils.CheckUsedBy(method, "Method_Public_Void_VRCPlayer_")
+                && XrefUtils.CheckUsedBy(method, "Method_Public_Virtual_Final_New_Void_IUser_"));
 
             MethodInfo[] pageMethods = typeof(UIPage).GetMethods()
                 .Where(method => method.Name.StartsWith("Method_Public_Void_UIPage_") && !method.Name.Contains("_PDM_"))


### PR DESCRIPTION
fixes _selectUserMethod xref for build 1159 and removes an unneeded call from UIX as `OpenQuickMenuPage` already opens the QuickMenu