### PR TITLE
UserHistory update and a couple other fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <VRChatPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/VRChat/')">$(HOME)/.steam/steam/steamapps/common/VRChat/</VRChatPath>
         <BaseOutputPath>$(MSBuildThisFileDirectory)bin</BaseOutputPath>
         <Deterministic>true</Deterministic>
-        <CopyLocal>false</CopyLocal>
+		<CopyModFiles>true</CopyModFiles>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <VRChatPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/VRChat/')">$(HOME)/.steam/steam/steamapps/common/VRChat/</VRChatPath>
         <BaseOutputPath>$(MSBuildThisFileDirectory)bin</BaseOutputPath>
         <Deterministic>true</Deterministic>
-		<CopyModFiles>true</CopyModFiles>
+        <CopyModFiles>true</CopyModFiles>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,8 @@
         <VRChatPath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/VRChat/')">$(HOME)/.steam/steam/steamapps/common/VRChat/</VRChatPath>
         <BaseOutputPath>$(MSBuildThisFileDirectory)bin</BaseOutputPath>
         <Deterministic>true</Deterministic>
-        <CopyModFiles>true</CopyModFiles>
+        <CopyLocal>false</CopyLocal>
+        <CopyModFiles Condition="'$(CopyModFiles)'==''">true</CopyModFiles>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <DebugSymbols Condition="'$(Configuration)'=='Release'">false</DebugSymbols>

--- a/UserHistory/Config.cs
+++ b/UserHistory/Config.cs
@@ -9,13 +9,15 @@ namespace UserHistory
         public static MelonPreferences_Entry<bool> useUIX;
         public static MelonPreferences_Entry<float> openButtonX;
         public static MelonPreferences_Entry<float> openButtonY;
+        public static MelonPreferences_Entry<bool> openInQuickMenu;
 
         public static void Init()
         {
             category = MelonPreferences.CreateCategory("UserHistory Config");
-            useUIX = category.CreateEntry(nameof(useUIX), true, "Should use UIX instead of regular buttons", null, !VRCUtils.IsUIXPresent);
-            openButtonX = category.CreateEntry(nameof(openButtonX), 0f, "X position of button. Does not apply when using UIX.");
-            openButtonY = category.CreateEntry(nameof(openButtonY), -1f, "Y position of button. Does not apply when using UIX.");
+            useUIX = category.CreateEntry(nameof(useUIX), false, "Should use UIX instead of regular buttons", null, !VRCUtils.IsUIXPresent);
+            openButtonX = category.CreateEntry(nameof(openButtonX), 300f, "X position of button. Does not apply when using UIX.");
+            openButtonY = category.CreateEntry(nameof(openButtonY), -60f, "Y position of button. Does not apply when using UIX.");
+            openInQuickMenu = category.CreateEntry(nameof(openInQuickMenu), true, "Should open the selected user in the QuickMenu\ninstead of big menu", null);
         }
     }
 }

--- a/UserInfoExtensions/Modules/BioButtons.cs
+++ b/UserInfoExtensions/Modules/BioButtons.cs
@@ -192,9 +192,12 @@ namespace UserInfoExtensions.Modules
         public override void OnUserInfoOpen()
         {
             userLanguages.Clear();
-            foreach (string tag in VRCUtils.ActiveUserInUserInfoMenu.tags) //Cant use where here because Il2Cpp List and regular List
+            if (VRCUtils.ActiveUserInUserInfoMenu != null)
             {
-                if (tag.StartsWith("language_")) userLanguages.Add(languageLookup[tag.Substring(9)]);
+                foreach (string tag in VRCUtils.ActiveUserInUserInfoMenu.tags) //Cant use where here because Il2Cpp List and regular List
+                {
+                    if (tag.StartsWith("language_")) userLanguages.Add(languageLookup[tag.Substring(9)]);
+                }
             }
         }
 


### PR DESCRIPTION
- fixed copying built dlls to the mods folder
- fixes UserHistory to make it work with the new UI, most changes are taken from Nirv's InstanceHistory, as both mods are essentially the same
- added an option to open the users in the QuickMenu instead of the big one
- added a null check to prevent a NullReferenceException in `OnUserInfoOpen`