### PR TITLE
Many fixes

### DIFF
--- a/AskToPortal/AskToPortalMod.cs
+++ b/AskToPortal/AskToPortalMod.cs
@@ -82,7 +82,7 @@ namespace AskToPortal
             if (!ShouldCheckUserPortal(dropper, photonView == null))
                 return true;
 
-            string roomId = __instance.field_Private_String_1;
+            string roomId = __instance.field_Private_String_4;
             string worldId = __instance.field_Private_ApiWorld_0.id;
             int roomPop = __instance.field_Private_Int32_0;
 

--- a/AskToPortal/RoomInfo.cs
+++ b/AskToPortal/RoomInfo.cs
@@ -100,7 +100,7 @@ namespace AskToPortal
                 if (ParseAmbiguousTag(tempTag) == "nonce")
                 {
                     if (region == null)
-                        region = "US";
+                        region = "US-West";
                     else
                         errors.Add("Nonce tag found before the instance type tag");
                     return;
@@ -168,6 +168,9 @@ namespace AskToPortal
                         break;
                     case "jp":
                         region = "Japan";
+                        break;
+                    case "use":
+                        region = "US-East";
                         break;
                     default:
                         errors.Add("Region tag exists, but value was not recognized");

--- a/PreviewScroller/PreviewScrollerMod.cs
+++ b/PreviewScroller/PreviewScrollerMod.cs
@@ -26,6 +26,7 @@ namespace PreviewScroller
             scrollerContainerRect.localScale = Vector3.one;
             scrollerContainerRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 400);
             scrollerContainerRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 650);
+            scrollerContainerRect.SetAsFirstSibling();
 
             GameObject scrollerContent = new GameObject("ScrollerContent", new UnhollowerBaseLib.Il2CppReferenceArray<Il2CppSystem.Type>(new Il2CppSystem.Type[2] { Il2CppType.Of<Image>(), Il2CppType.Of<RectTransform>() }));
             RectTransform scrollerContentRect = scrollerContent.GetComponent<RectTransform>();

--- a/ReloadAvatars/ReloadAvatarsMod.cs
+++ b/ReloadAvatars/ReloadAvatarsMod.cs
@@ -30,7 +30,7 @@ namespace ReloadAvatars
             {
                 try
                 {
-                    VRCUtils.ReloadAvatar(VRCUtils.ActivePlayerInUserInfoMenu);
+                    VRCUtils.ReloadAvatar(VRCUtils.ActivePlayerInUserSelectMenu);
                 }
                 catch (Exception ex)
                 {

--- a/SelectYourself/SelectYourselfMod.cs
+++ b/SelectYourself/SelectYourselfMod.cs
@@ -21,7 +21,10 @@ namespace SelectYourself
             selectYourselfPref.OnValueChangedUntyped += OnPrefChange;
 
             ExpansionKitApi.GetExpandedMenu(ExpandedMenu.QuickMenu).AddSimpleButton("Select Yourself",
-                new Action(() => UiManager.OpenUserInQuickMenu(Player.prop_Player_0.prop_APIUser_0)),
+                new Action(() => {
+                    UiManager.OpenQuickMenuPage("QuickMenuHere");
+                    UiManager.OpenUserInQuickMenu(Player.prop_Player_0.prop_APIUser_0);
+                }),
                 new Action<GameObject>((gameObject) => { selectYourselfButton = gameObject; OnPrefChange(); }));
         }
         public static void OnPrefChange()

--- a/VRChatUtilityKit/Utilities/VRCUtils.cs
+++ b/VRChatUtilityKit/Utilities/VRCUtils.cs
@@ -94,7 +94,14 @@ namespace VRChatUtilityKit.Utilities
         /// </summary>
         public static IUser ActiveUserInUserSelectMenu => _quickMenuInstance.field_Private_UIPage_1.gameObject.active ?
                                                               _quickMenuInstance.field_Private_UIPage_1.Cast<SelectedUserMenuQM>().field_Private_IUser_0 :
-                                                              _quickMenuInstance.field_Private_UIPage_2.gameObject.active ? _quickMenuInstance.field_Private_UIPage_2.Cast<SelectedUserMenuQM>().field_Private_IUser_0 : null;                                                                
+                                                              _quickMenuInstance.field_Private_UIPage_2.gameObject.active ? _quickMenuInstance.field_Private_UIPage_2.Cast<SelectedUserMenuQM>().field_Private_IUser_0 : null;
+
+        /// <summary>
+        /// Returns the active player in the user select menu.
+        /// </summary>
+        public static VRCPlayer ActivePlayerInUserSelectMenu => PlayerManager.field_Private_Static_PlayerManager_0.field_Private_List_1_Player_0.ToArray()
+                                                                .FirstOrDefault((Player player) => player.field_Private_APIUser_0 != null 
+                                                                && player.field_Private_APIUser_0.id == ActiveUserInUserSelectMenu.ToAPIUser().id)._vrcplayer;
 
         private static MethodInfo _loadAvatarMethod;
         private static MethodInfo _reloadAllAvatarsMethod;


### PR DESCRIPTION
went through all the mods to check if all worked, here's the stuff i found broken and i fixed:

- AskToPortal: fixed roomId and added `US-East` and `US-West` as regions
- PreviewScroller: fixed Avatar Fallback buttons not being clickable when the mod was active
- VRChatUtilityKit: added a method to get the active selected player in the QuickMenu
- ReloadAvatars: fixed reloading single user's avatar
- SelectYourself: made it so it switches to the `Here` tab when selecting yourself for consistency although the mod is not necessary anymore as you can now select yourself from the QuickMenu