### PR TITLE
1169 fixes

### DIFF
--- a/VRChatUtilityKit/Ui/SingleButton.cs
+++ b/VRChatUtilityKit/Ui/SingleButton.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using VRC.DataModel.Core;
+using BindingExtensions = ObjectPublicAbstractSealedVoGa9326CoAc63Ac26CoUnique;
 
 namespace VRChatUtilityKit.Ui
 {

--- a/VRChatUtilityKit/Ui/SubMenu.cs
+++ b/VRChatUtilityKit/Ui/SubMenu.cs
@@ -71,7 +71,7 @@ namespace VRChatUtilityKit.Ui
             TextComponent = rectTransform.Find("Header_H1/LeftItemContainer/Text_Title").GetComponent<TextMeshProUGUI>();
             Text = headerText;
             uiPage = gameObject.AddComponent<UIPage>();
-            uiPage.field_Private_MenuStateController_0 = UiManager.QMStateController;
+            uiPage.field_Protected_MenuStateController_0 = UiManager.QMStateController;
             uiPage.field_Public_String_0 = pageName;
 
             UiManager.QMStateController.field_Private_Dictionary_2_String_UIPage_0.Add(pageName, uiPage);

--- a/VRChatUtilityKit/Ui/ToggleButton.cs
+++ b/VRChatUtilityKit/Ui/ToggleButton.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEngine.UI;
 using VRC.DataModel.Core;
+using BindingExtensions = ObjectPublicAbstractSealedVoGa9326CoAc63Ac26CoUnique;
 
 namespace VRChatUtilityKit.Ui
 {

--- a/VRChatUtilityKit/Ui/UiManager.cs
+++ b/VRChatUtilityKit/Ui/UiManager.cs
@@ -137,7 +137,7 @@ namespace VRChatUtilityKit.Ui
             _closeMenuMethod = typeof(UIManagerImpl).GetMethods()
                 .First(method => method.Name.StartsWith("Method_Public_Virtual_Final_New_Void_") && XrefScanner.XrefScan(method).Count() == 2);
             _closeQuickMenuMethod = typeof(UIManagerImpl).GetMethods()
-                .First(method => method.Name.StartsWith("Method_Public_Void_Boolean_") && XrefUtils.CheckUsedBy(method, _closeMenuMethod.Name));
+                .First(method => method.Name.StartsWith("Method_Public_Void_Boolean_") && XrefUtils.CheckUsing(method, "Method_Private_Void_") && !XrefUtils.CheckUsing(method, "SetActive"));
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(_closeQuickMenuMethod, null, new HarmonyMethod(typeof(UiManager).GetMethod(nameof(OnQuickMenuClose), BindingFlags.NonPublic | BindingFlags.Static)));
 
             _openQuickMenuMethod = typeof(UIManagerImpl).GetMethods()

--- a/VRChatUtilityKit/Utilities/NetworkEvents.cs
+++ b/VRChatUtilityKit/Utilities/NetworkEvents.cs
@@ -216,7 +216,7 @@ namespace VRChatUtilityKit.Utilities
 
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(typeof(FriendsListManager).GetMethod("Method_Private_Void_String_0"), new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnUnfriend), BindingFlags.NonPublic | BindingFlags.Static)));
 
-            MethodInfo onSetupFlagsReceivedMethod = typeof(VRCPlayer).GetMethods().First(mi => mi.ReturnType.IsEnum && mi.GetParameters().Length == 1 && mi.GetParameters()[0].ParameterType == typeof(Il2CppSystem.Collections.Hashtable) && XrefUtils.CheckStrings(mi, "Failed to read showSocialRank for {0}"));
+            MethodInfo onSetupFlagsReceivedMethod = typeof(VRCPlayer).GetMethods().First(mi => mi.Name.StartsWith("Method_Public_Static_get_Hashtable_"));
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(onSetupFlagsReceivedMethod, null, new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnSetupFlagsReceive), BindingFlags.NonPublic | BindingFlags.Static)));
 
             foreach (MethodInfo socialRankChangeMethod in typeof(ProfileWingMenu).GetMethods().Where(method => method.Name.StartsWith("Method_Private_Void_Boolean_")))

--- a/VRChatUtilityKit/Utilities/NetworkEvents.cs
+++ b/VRChatUtilityKit/Utilities/NetworkEvents.cs
@@ -216,8 +216,8 @@ namespace VRChatUtilityKit.Utilities
 
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(typeof(FriendsListManager).GetMethod("Method_Private_Void_String_0"), new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnUnfriend), BindingFlags.NonPublic | BindingFlags.Static)));
 
-            MethodInfo onSetupFlagsReceivedMethod = typeof(VRCPlayer).GetMethods().First(mi => mi.Name.StartsWith("Method_Public_Static_get_Hashtable_"));
-            VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(onSetupFlagsReceivedMethod, null, new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnSetupFlagsReceive), BindingFlags.NonPublic | BindingFlags.Static)));
+            //MethodInfo onSetupFlagsReceivedMethod = typeof(VRCPlayer).GetMethods().First(mi => mi.Name.StartsWith("Method_Public_Static_get_Hashtable_"));
+            //VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(onSetupFlagsReceivedMethod, null, new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnSetupFlagsReceive), BindingFlags.NonPublic | BindingFlags.Static)));
 
             foreach (MethodInfo socialRankChangeMethod in typeof(ProfileWingMenu).GetMethods().Where(method => method.Name.StartsWith("Method_Private_Void_Boolean_")))
                 VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(socialRankChangeMethod, null, new HarmonyMethod(typeof(NetworkEvents).GetMethod(nameof(OnShowSocialRankChange), BindingFlags.NonPublic | BindingFlags.Static)));

--- a/VRChatUtilityKit/VRChatUtilityKitMod.cs
+++ b/VRChatUtilityKit/VRChatUtilityKitMod.cs
@@ -5,7 +5,7 @@ using MelonLoader;
 using VRChatUtilityKit.Ui;
 using VRChatUtilityKit.Utilities;
 
-[assembly: MelonInfo(typeof(VRChatUtilityKit.VRChatUtilityKitMod), "VRChatUtilityKit", "1.3.1", "Sleepers", "https://github.com/SleepyVRC/Mods")]
+[assembly: MelonInfo(typeof(VRChatUtilityKit.VRChatUtilityKitMod), "VRChatUtilityKit", "1.3.2", "Sleepers", "https://github.com/SleepyVRC/Mods")]
 [assembly: MelonGame("VRChat", "VRChat")]
 [assembly: MelonPriority(-100)]
 


### PR DESCRIPTION
this PR fixes thingies to support build 1169 (nice)

`NetworkEvents.onSetupFlagsReceivedMethod` is commented out as i couldnt find where `Method_Private_NetworkChange_Hashtable_PDM_1` (the one that was getting used in 1160) is gone now

`BindingExtensions` changed names, so we can either wait for deob map to add it or do the do and add `using BindingExtensions = ObjectPublicAbstractSealedVoGa9326CoAc63Ac26CoUnique;` until it gets fixed